### PR TITLE
Refactor Core::Type to AST::Type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ elseif (NOT FLEX_FOUND)
 endif()
 
 # Build Core target
-add_library(core SHARED src/core/Type.cpp)
+add_library(core SHARED src/core/blank.cpp)
 
 # Build AST target
 set (AST_SOURCES
@@ -33,6 +33,7 @@ set (AST_SOURCES
     src/frontend/ast/ClassDeclNode.cpp
     src/frontend/ast/IfStatementNode.cpp
     src/frontend/ast/MethodCallExpNode.cpp
+    src/frontend/ast/Type.cpp
 )
 add_library(ast SHARED ${AST_SOURCES})
 

--- a/include/minijavab/frontend/ASTClassTable.h
+++ b/include/minijavab/frontend/ASTClassTable.h
@@ -2,7 +2,7 @@
 #include <string>
 #include <unordered_map>
 #include "minijavab/frontend/ast/ast.h"
-#include "minijavab/core/Type.h"
+#include "minijavab/frontend/ast/Type.h"
 
 namespace MiniJavab {
 namespace Frontend {
@@ -17,7 +17,7 @@ class ASTVariable {
         std::string Name;
 
         // The Type of this variable
-        Core::Type* Type;
+        AST::Type* Type;
 
         // The AST node of the variable declaration
         AST::VarDeclNode* VarDecl;
@@ -43,7 +43,7 @@ class ASTMethod {
         std::string Name;
 
         // The type of value this method returns
-        Core::Type* ReturnType;
+        AST::Type* ReturnType;
 
         // The AST Node of the method declaration
         AST::MethodDeclNode* MethodDecl;

--- a/include/minijavab/frontend/ast/ExpNode.h
+++ b/include/minijavab/frontend/ast/ExpNode.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "minijavab/frontend/ast/Node.h"
-#include "minijavab/core/Type.h"
+#include "minijavab/frontend/ast/Type.h"
 
 #include <optional>
 
@@ -89,7 +89,7 @@ class ExpNode : public Node {
         ExpKind Kind;
 
         /// The Type of this expression deduced during typechecking
-        std::optional<Core::Type*> ExpressionType = std::nullopt;
+        std::optional<AST::Type*> ExpressionType = std::nullopt;
 };
 
 }}} // end namespace

--- a/include/minijavab/frontend/ast/Type.h
+++ b/include/minijavab/frontend/ast/Type.h
@@ -4,7 +4,8 @@
 #include <vector>
 
 namespace MiniJavab {
-namespace Core {
+namespace Frontend {
+namespace AST {
 
 enum class TypeKind {
     Integer,
@@ -81,4 +82,4 @@ class ArrayType : public Type {
         int Dimensions;
 };
 
-}} // end namespace
+}}} // end namespace

--- a/include/minijavab/frontend/ast/TypeNode.h
+++ b/include/minijavab/frontend/ast/TypeNode.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <string>
 #include <stdio.h>
+
 #include "minijavab/frontend/ast/Node.h"
+#include "minijavab/frontend/ast/Type.h"
 
 namespace MiniJavab {
 namespace Frontend {
@@ -26,6 +28,10 @@ class TypeNode : public Node {
         virtual bool IsBooleanType() { return Kind == TypeNodeKind::Boolean; }
         virtual bool IsObjectType() { return Kind == TypeNodeKind::Object; }
         virtual bool IsArrayType() { return Kind == TypeNodeKind::Array; }
+
+        /// Resolve the AST representation of a value type to a Type object
+        /// @return A resolved type object
+        virtual Type* ResolveType() = 0;
         
         TypeNodeKind Kind;
 };
@@ -35,6 +41,7 @@ class IntegerTypeNode : public TypeNode {
         IntegerTypeNode() : TypeNode(TypeNodeKind::Integer) {}
         void Dump(std::ostream& out=std::cout) override { out << "Integer Type" << std::endl; }
         void Str(std::ostream& out) override { out << "int"; }
+        virtual Type* ResolveType() override { return new AST::IntegerType(); }
 };
 
 class StringTypeNode : public TypeNode {
@@ -42,6 +49,7 @@ class StringTypeNode : public TypeNode {
         StringTypeNode() : TypeNode(TypeNodeKind::String) {}
         void Dump(std::ostream& out=std::cout) override { out << "String Type" << std::endl; }
         void Str(std::ostream& out) override { out << "String"; }
+        virtual Type* ResolveType() override { return new AST::StringType(); }
 };
 
 class BooleanTypeNode : public TypeNode {
@@ -49,6 +57,7 @@ class BooleanTypeNode : public TypeNode {
         BooleanTypeNode() : TypeNode(TypeNodeKind::Boolean) {}
         void Dump(std::ostream& out=std::cout) override { out << "Boolean Type" << std::endl; }
         void Str(std::ostream& out) override { out << "boolean"; }
+        virtual Type* ResolveType() override { return new AST::BooleanType(); }
 };
 
 class VoidTypeNode : public TypeNode {
@@ -56,6 +65,7 @@ class VoidTypeNode : public TypeNode {
         VoidTypeNode() : TypeNode(TypeNodeKind::Void) {}
         void Dump(std::ostream& out=std::cout) override { out << "Void Type" << std::endl; }
         void Str(std::ostream& out) override { out << "void"; }
+        virtual Type* ResolveType() override { return new AST::VoidType(); }
 };
 
 class ObjectTypeNode : public TypeNode {
@@ -63,6 +73,7 @@ class ObjectTypeNode : public TypeNode {
         ObjectTypeNode(std::string objectType);
         void Dump(std::ostream& out=std::cout) override { out << ObjectType << " Type" << std::endl; }
         void Str(std::ostream& out) override { out << ObjectType; }
+        virtual Type* ResolveType() override { return new AST::ObjectType(ObjectType); }
 
         std::string ObjectType;
 };
@@ -73,6 +84,7 @@ class ArrayTypeNode : public TypeNode {
         void Increase() { Dimensions += 1; }
         void Dump(std::ostream& out=std::cout) override;
         void Str(std::ostream& out) override;
+        virtual Type* ResolveType() override { return new AST::ArrayType(BaseType->ResolveType(), Dimensions); }
 
         TypeNode* BaseType;
         int Dimensions;

--- a/include/minijavab/frontend/frontend.h
+++ b/include/minijavab/frontend/frontend.h
@@ -3,7 +3,6 @@
 #include <iostream>
 #include "minijavab/frontend/ast/ast.h"
 #include "minijavab/frontend/ASTClassTable.h"
-#include "minijavab/core/Type.h"
 
 namespace MiniJavab {
 namespace Frontend {
@@ -12,12 +11,6 @@ namespace Frontend {
 // LoadClassTableFromAST()
 // CreateIRModule()
 // GetIRLinker()
-
-/// Convert an AST representation of a value type to a Core representation
-/// @param node The AST node to convert
-/// @return The Core representation of the AST node
-/// @see Core::Type
-Core::Type* ConvertTypeNodeToType(AST::TypeNode* node);
 
 // Create a Program AST tree from the fileName
 AST::Node* ParseProgramFile(std::string fileName, std::ostream& errs=std::cerr);

--- a/src/frontend/ASTClassTable.cpp
+++ b/src/frontend/ASTClassTable.cpp
@@ -8,14 +8,14 @@ ASTVariable::ASTVariable(AST::VarDeclNode* varDecl)
     : VarDecl(varDecl)
 {
     Name = varDecl->Name;
-    Type = ConvertTypeNodeToType(varDecl->Type);
+    Type = varDecl->Type->ResolveType();
 }
 
 ASTMethod::ASTMethod(AST::MethodDeclNode* methodDecl)
     : MethodDecl(methodDecl)
 {
     Name = methodDecl->Name;
-    ReturnType = ConvertTypeNodeToType(methodDecl->Type);
+    ReturnType = methodDecl->Type->ResolveType();
 
     // load variable info by examining the MethodDeclNode's variable list
     for (AST::VarDeclNode* variableDecl: methodDecl->Variables) {

--- a/src/frontend/Frontend.cpp
+++ b/src/frontend/Frontend.cpp
@@ -5,24 +5,6 @@
 namespace MiniJavab {
 namespace Frontend {
 
-Core::Type* ConvertTypeNodeToType(AST::TypeNode* node) {
-    if (node->IsIntegerType()) { return new Core::IntegerType(); }
-    else if (node->IsVoidType()) { return new Core::VoidType(); }
-    else if (node->IsStringType()) { return new Core::StringType(); }
-    else if (node->IsBooleanType()) { return new Core::BooleanType(); }
-    else if (node->IsObjectType()) {
-        AST::ObjectTypeNode* typeNode = dynamic_cast<AST::ObjectTypeNode*>(node);
-        return new Core::ObjectType(typeNode->ObjectType);
-    }
-    else if (node->IsArrayType()) {
-        AST::ArrayTypeNode* typeNode = dynamic_cast<AST::ArrayTypeNode*>(node);
-        return new Core::ArrayType(ConvertTypeNodeToType(typeNode->BaseType), typeNode->Dimensions);
-    }
-
-    assert(false && "AST TypeNode not recognized");
-    return nullptr; // unreachable
-}
-
 AST::Node* ParseProgramFile(std::string fileName, std::ostream& errs) {
     Parser::ScanResult* result = Parser::ParseFileToAST(fileName);
     if (result->Result == nullptr) {

--- a/src/frontend/TypeChecker.cpp
+++ b/src/frontend/TypeChecker.cpp
@@ -9,15 +9,15 @@ struct TypeCheckProcedure {
         : Table(table),
         Errs(errs) {}
 
-    Core::Type* FatalError(std::string message);
-    Core::Type* GetType(AST::BinaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
-    Core::Type* GetType(AST::IndexExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
-    Core::Type* GetType(AST::LengthExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
-    Core::Type* GetType(AST::LiteralExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
-    Core::Type* GetType(AST::MethodCallExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
-    Core::Type* GetType(AST::ObjectExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
-    Core::Type* GetType(AST::UnaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
-    Core::Type* GetType(AST::ExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* FatalError(std::string message);
+    AST::Type* GetType(AST::BinaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* GetType(AST::IndexExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* GetType(AST::LengthExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* GetType(AST::LiteralExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* GetType(AST::MethodCallExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* GetType(AST::ObjectExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* GetType(AST::UnaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
+    AST::Type* GetType(AST::ExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
     void TypeCheck(AST::AssignmentStatementNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
     void TypeCheck(AST::IfStatementNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
     void TypeCheck(AST::PrintStatementNode* const node, ASTClass* const classObject, ASTMethod* const methodObject);
@@ -47,18 +47,18 @@ ASTVariable* findVariableOrParameter(std::string name, ASTClass* const classObje
     return nullptr;
 }
 
-Core::Type* TypeCheckProcedure::FatalError(std::string message) {
+AST::Type* TypeCheckProcedure::FatalError(std::string message) {
     ValidCheck = false;
     Errs << message << "\n";
     return nullptr;
 }
-Core::Type* TypeCheckProcedure::GetType(AST::BinaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::BinaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     if (node->ExpressionType != std::nullopt) {
         return *(node->ExpressionType);
     }
     
-    Core::Type* lhsType = GetType(node->LeftSide, classObject, methodObject);
-    Core::Type* rhsType = GetType(node->RightSide, classObject, methodObject);
+    AST::Type* lhsType = GetType(node->LeftSide, classObject, methodObject);
+    AST::Type* rhsType = GetType(node->RightSide, classObject, methodObject);
     if (lhsType == nullptr) {
         return FatalError("Failed to get Left Hand Side type");
     }
@@ -86,7 +86,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::BinaryExpNode* const node, ASTClass
                 (!lhsType->IsIntegerType() && !rhsType->IsIntegerType())) {
                 return FatalError("Both sides of the binary expression must be the same type");
             }
-            node->ExpressionType = new Core::BooleanType();
+            node->ExpressionType = new AST::BooleanType();
             return *(node->ExpressionType);
         }
         // int -> boolean operations
@@ -100,7 +100,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::BinaryExpNode* const node, ASTClass
             if (!rhsType->IsIntegerType()) {
                 return FatalError("Right Hand Side must be a integer expression");
             }
-            node->ExpressionType = new Core::BooleanType();
+            node->ExpressionType = new AST::BooleanType();
             return *(node->ExpressionType);
         }
         // int -> int operations
@@ -122,7 +122,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::BinaryExpNode* const node, ASTClass
         }
     }
 }
-Core::Type* TypeCheckProcedure::GetType(AST::IndexExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::IndexExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     if (node->ExpressionType != std::nullopt) {
         return *(node->ExpressionType);
     }
@@ -148,7 +148,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::IndexExpNode* const node, ASTClass*
     }
 
     // make sure the accessor indices are <= to the type dimensions 
-    Core::ArrayType* variableType = static_cast<Core::ArrayType*>(variable->Type);
+    AST::ArrayType* variableType = static_cast<AST::ArrayType*>(variable->Type);
     if (node->Index->Expressions.size() > variableType->Dimensions) {
         return FatalError("Cannot access " + std::to_string(node->Index->Expressions.size()) + " dimensions of a " + std::to_string(variableType->Dimensions) + " dimensional array");
     }
@@ -158,11 +158,11 @@ Core::Type* TypeCheckProcedure::GetType(AST::IndexExpNode* const node, ASTClass*
         node->ExpressionType = variableType->BaseType;
     }
     else { // else we're accessing a sub-array within the array (eg. arr[0] of int[][] arr)
-        node->ExpressionType = new Core::ArrayType(variableType->BaseType, node->Index->Expressions.size());
+        node->ExpressionType = new AST::ArrayType(variableType->BaseType, node->Index->Expressions.size());
     }
     return *(node->ExpressionType);
 }
-Core::Type* TypeCheckProcedure::GetType(AST::LengthExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::LengthExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     if (node->ExpressionType == std::nullopt) {
         // lookup the object
         ASTVariable* parameter = findVariableOrParameter(node->Name, classObject, methodObject);
@@ -172,31 +172,31 @@ Core::Type* TypeCheckProcedure::GetType(AST::LengthExpNode* const node, ASTClass
         if (!parameter->Type->IsArrayType()) {
             return FatalError("Can't use the \".length\" method on a non-array type: " + node->Name);
         }
-        node->ExpressionType = new Core::IntegerType();
+        node->ExpressionType = new AST::IntegerType();
     }
     return *(node->ExpressionType);
 }
-Core::Type* TypeCheckProcedure::GetType(AST::LiteralExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::LiteralExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     if (node->ExpressionType != std::nullopt) {
         return *(node->ExpressionType);
     }
 
     if (node->IsIntegerLiteral()) {
-        node->ExpressionType = new Core::IntegerType();
+        node->ExpressionType = new AST::IntegerType();
         return *(node->ExpressionType);
     }
     else if (node->IsBooleanLiteral()) {
-        node->ExpressionType = new Core::BooleanType();
+        node->ExpressionType = new AST::BooleanType();
         return *(node->ExpressionType);
     }
     else if (node->IsStringLiteral()) {
-        node->ExpressionType = new Core::StringType();
+        node->ExpressionType = new AST::StringType();
         return *(node->ExpressionType);
     }
 
     assert(false && "Unrecognized literal type");
 }
-Core::Type* TypeCheckProcedure::GetType(AST::MethodCallExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::MethodCallExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     if (node->ExpressionType != std::nullopt) {
         return *(node->ExpressionType);
     }
@@ -226,7 +226,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::MethodCallExpNode* const node, ASTC
                 if (!parameter->Type->IsObjectType()) {
                     return FatalError("Cannot invoke method on non-object type: " + namedCalledObject->Name);
                 }
-                Core::ObjectType* objType = dynamic_cast<Core::ObjectType*>(parameter->Type);
+                AST::ObjectType* objType = dynamic_cast<AST::ObjectType*>(parameter->Type);
                 calledObject = Table->GetClass(objType->TypeName);
                 if (calledObject == nullptr) {
                     return FatalError("Parameter has invalid type: " + namedCalledObject->Name);
@@ -236,7 +236,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::MethodCallExpNode* const node, ASTC
                 if (!methodVariable->Type->IsObjectType()) {
                     return FatalError("Cannot invoke method on non-object type: " + namedCalledObject->Name);
                 }
-                Core::ObjectType* objType = dynamic_cast<Core::ObjectType*>(methodVariable->Type);
+                AST::ObjectType* objType = dynamic_cast<AST::ObjectType*>(methodVariable->Type);
                 calledObject = Table->GetClass(objType->TypeName);
                 if (calledObject == nullptr) {
                     return FatalError("Method variable has invalid type: " + namedCalledObject->Name);
@@ -246,7 +246,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::MethodCallExpNode* const node, ASTC
                 if (!methodVariable->Type->IsObjectType()) {
                     return FatalError("Cannot invoke method on non-object type: " + namedCalledObject->Name);
                 }
-                Core::ObjectType* objType = dynamic_cast<Core::ObjectType*>(classVariable->Type);
+                AST::ObjectType* objType = dynamic_cast<AST::ObjectType*>(classVariable->Type);
                 calledObject = Table->GetClass(objType->TypeName);
                 if (calledObject == nullptr) {
                     return FatalError("Method variable has invalid type: " + namedCalledObject->Name);
@@ -271,7 +271,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::MethodCallExpNode* const node, ASTC
     node->ExpressionType = calledMethodObject->ReturnType;
     return *(node->ExpressionType);
 }
-Core::Type* TypeCheckProcedure::GetType(AST::ObjectExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::ObjectExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     if (node->ExpressionType != std::nullopt) {
         return *(node->ExpressionType);
     }
@@ -286,7 +286,7 @@ Core::Type* TypeCheckProcedure::GetType(AST::ObjectExpNode* const node, ASTClass
             if (classDefinition == nullptr) {
                 return FatalError("Cannot construct object of type \"" + namedObjectNode->Name + "\", class doesn't exist");
             }
-            node->ExpressionType = new Core::ObjectType(classDefinition->Name);
+            node->ExpressionType = new AST::ObjectType(classDefinition->Name);
             return *(node->ExpressionType);
         }
         else {
@@ -300,27 +300,27 @@ Core::Type* TypeCheckProcedure::GetType(AST::ObjectExpNode* const node, ASTClass
         }
     }
     else if (objectNode->IsThisObject()) {
-        node->ExpressionType = new Core::ObjectType(classObject->Name);
+        node->ExpressionType = new AST::ObjectType(classObject->Name);
         return *(node->ExpressionType);
     }
     else if (objectNode->IsNewArray()) {
         AST::NewArrayObjectNode* newArrayNode = static_cast<AST::NewArrayObjectNode*>(objectNode);
         size_t dimensions = newArrayNode->Index->Expressions.size();
         if (newArrayNode->Type->IsBooleanType()) {
-            node->ExpressionType = new Core::ArrayType(new Core::BooleanType(), dimensions);
+            node->ExpressionType = new AST::ArrayType(new AST::BooleanType(), dimensions);
             return *(node->ExpressionType);
         }
         else if (newArrayNode->Type->IsIntegerType()) {
-            node->ExpressionType = new Core::ArrayType(new Core::IntegerType(), dimensions);
+            node->ExpressionType = new AST::ArrayType(new AST::IntegerType(), dimensions);
             return *(node->ExpressionType);
         }
         else if (newArrayNode->Type->IsStringType()) {
-            node->ExpressionType = new Core::ArrayType(new Core::StringType(), dimensions);
+            node->ExpressionType = new AST::ArrayType(new AST::StringType(), dimensions);
             return *(node->ExpressionType);
         }
         else if (newArrayNode->Type->IsObjectType()) {
             AST::ObjectTypeNode* objectType = static_cast<AST::ObjectTypeNode*>(newArrayNode->Type);
-            node->ExpressionType = new Core::ArrayType(new Core::ObjectType(objectType->ObjectType), dimensions);
+            node->ExpressionType = new AST::ArrayType(new AST::ObjectType(objectType->ObjectType), dimensions);
             return *(node->ExpressionType);
         }
         else {
@@ -331,13 +331,13 @@ Core::Type* TypeCheckProcedure::GetType(AST::ObjectExpNode* const node, ASTClass
     node->Dump();
     assert(false && "Unrecognized object expression type");
 }
-Core::Type* TypeCheckProcedure::GetType(AST::UnaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::UnaryExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     return GetType(node->Expression, classObject, methodObject);
 }
 
 void TypeCheckProcedure::TypeCheck(AST::AssignmentStatementNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     // verify the variable exists
-    Core::Type* variableType = nullptr;
+    AST::Type* variableType = nullptr;
     if (ASTVariable* parameter = methodObject->GetParameter(node->Name)) {
         variableType = parameter->Type;
     }
@@ -353,7 +353,7 @@ void TypeCheckProcedure::TypeCheck(AST::AssignmentStatementNode* const node, AST
     }
 
     // get the type of the expression
-    Core::Type* expressionType = GetType(node->Expression, classObject, methodObject);
+    AST::Type* expressionType = GetType(node->Expression, classObject, methodObject);
     if (expressionType == nullptr) {
         FatalError("Failed to get expression type for assignment statement");
         return;
@@ -362,7 +362,7 @@ void TypeCheckProcedure::TypeCheck(AST::AssignmentStatementNode* const node, AST
     // verify the types match
     if (node->IsIndexedAssignment()) {
         // find variable type
-        Core::Type* variableType = nullptr;
+        AST::Type* variableType = nullptr;
         if (ASTVariable* parameter = methodObject->GetParameter(node->Name)) {
             variableType = parameter->Type;
         }
@@ -383,7 +383,7 @@ void TypeCheckProcedure::TypeCheck(AST::AssignmentStatementNode* const node, AST
         }
 
         // get expression type
-        Core::Type* expressionType = GetType(node->Expression, classObject, methodObject);
+        AST::Type* expressionType = GetType(node->Expression, classObject, methodObject);
         if (expressionType == nullptr) {
             FatalError("Failed to get type of assignment expression");
             return;
@@ -391,7 +391,7 @@ void TypeCheckProcedure::TypeCheck(AST::AssignmentStatementNode* const node, AST
 
         // verify types match
         // TODO verify assigning to a lower dimension in a multi dimensional array
-        Core::ArrayType* variableArrayType = static_cast<Core::ArrayType*>(variableType);
+        AST::ArrayType* variableArrayType = static_cast<AST::ArrayType*>(variableType);
         if (!expressionType->Equals(variableArrayType->BaseType)) {
             FatalError("Type mismatch");
             return;
@@ -406,7 +406,7 @@ void TypeCheckProcedure::TypeCheck(AST::AssignmentStatementNode* const node, AST
 
 void TypeCheckProcedure::TypeCheck(AST::IfStatementNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     // type of the expression must be a boolean type
-    Core::Type* conditionalType = GetType(node->Expression, classObject, methodObject);
+    AST::Type* conditionalType = GetType(node->Expression, classObject, methodObject);
     if (conditionalType == nullptr) {
         FatalError("Failed to get type for if statement");
     }
@@ -425,7 +425,7 @@ void TypeCheckProcedure::TypeCheck(AST::PrintStatementNode* const node, ASTClass
     // we only need to check the type of Print(expression) because Print(string) is always the correct type
     if (node->IsPrintExpressionStatement()) {
         AST::PrintExpStatementNode* printExpNode = dynamic_cast<AST::PrintExpStatementNode*>(node);
-        Core::Type* expressionType = GetType(printExpNode->Expression, classObject, methodObject);
+        AST::Type* expressionType = GetType(printExpNode->Expression, classObject, methodObject);
         if (expressionType == nullptr) { 
             ValidCheck = false; 
             Errs << "Failed to get expression type\n";
@@ -440,7 +440,7 @@ void TypeCheckProcedure::TypeCheck(AST::PrintStatementNode* const node, ASTClass
 
 void TypeCheckProcedure::TypeCheck(AST::ReturnStatementNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     // verify the type of the return expression is the same as the method body
-    Core::Type* expressionType = GetType(node->Expression, classObject, methodObject);
+    AST::Type* expressionType = GetType(node->Expression, classObject, methodObject);
     if (expressionType == nullptr) {
         FatalError("Failed to get return expression type");
     }
@@ -453,7 +453,7 @@ void TypeCheckProcedure::TypeCheck(AST::ReturnStatementNode* const node, ASTClas
 
 void TypeCheckProcedure::TypeCheck(AST::WhileStatementNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     // verify the type of the conditional expression is a boolean
-    Core::Type* expressionType = GetType(node->Expression, classObject, methodObject);
+    AST::Type* expressionType = GetType(node->Expression, classObject, methodObject);
     if (expressionType == nullptr) {
         FatalError("Failed to get conditional expression type");
     }
@@ -467,7 +467,7 @@ void TypeCheckProcedure::TypeCheck(AST::WhileStatementNode* const node, ASTClass
     TypeCheck(node->Statement, classObject, methodObject);
 }
 
-Core::Type* TypeCheckProcedure::GetType(AST::ExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
+AST::Type* TypeCheckProcedure::GetType(AST::ExpNode* const node, ASTClass* const classObject, ASTMethod* const methodObject) {
     if (node->IsBinaryExpression()) {
         return GetType(static_cast<AST::BinaryExpNode*>(node), classObject, methodObject);
     }
@@ -534,7 +534,7 @@ void TypeCheckProcedure::TypeCheck(AST::MethodDeclNode* const node, ASTClass* co
 
     // check if the return expression is the right type
     if (node->ReturnExp != nullptr) {
-        Core::Type* returnType = GetType(node->ReturnExp, classObject, methodObject);
+        AST::Type* returnType = GetType(node->ReturnExp, classObject, methodObject);
 
         if (returnType == nullptr) {
             Errs << "Failed to get return type\n";

--- a/src/frontend/ast/Type.cpp
+++ b/src/frontend/ast/Type.cpp
@@ -1,7 +1,8 @@
-#include "minijavab/core/Type.h"
+#include "minijavab/frontend/ast/Type.h"
 
 namespace MiniJavab {
-namespace Core {
+namespace Frontend {
+namespace AST {
 
 bool ObjectType::Equals(Type* other) {
     // Verify other is an object type
@@ -52,4 +53,4 @@ bool ArrayType::Equals(Type* other) {
     return Dimensions == otherArrayType->Dimensions;
 }
 
-}} // end namespace
+}}} // end namespace


### PR DESCRIPTION
This PR moves out `Core::Type` to `AST::Type` to make room for IR typing information.