### PR TITLE
Start implementing function lowering with local variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ add_library(cmdline STATIC src/cmdline/options.cpp)
 target_include_directories(cmdline PUBLIC include/)
 
 set(INSTRUCTIONS
-    src/core/ir/Instructions/Alloc.cpp)
+    src/core/ir/Instructions/Alloc.cpp
+    src/core/ir/Instructions/Store.cpp)
 
 # Build Core target
 add_library(core SHARED
@@ -43,6 +44,7 @@ add_library(core SHARED
     src/core/ir/Immediate.cpp
     src/core/ir/Instruction.cpp
     src/core/ir/IRBuilder.cpp
+    src/core/ir/Parameter.cpp
     ${INSTRUCTIONS})
 
 # Build AST target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ endif()
 add_library(cmdline STATIC src/cmdline/options.cpp)
 target_include_directories(cmdline PUBLIC include/)
 
+set(INSTRUCTIONS
+    src/core/ir/Instructions/Alloc.cpp)
+
 # Build Core target
 add_library(core SHARED
     src/core/ir/Type.cpp
@@ -39,7 +42,8 @@ add_library(core SHARED
     src/core/ir/Module.cpp
     src/core/ir/Immediate.cpp
     src/core/ir/Instruction.cpp
-    src/core/ir/IRBuilder.cpp)
+    src/core/ir/IRBuilder.cpp
+    ${INSTRUCTIONS})
 
 # Build AST target
 set (AST_SOURCES

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -57,8 +57,11 @@ module "printIfTrue.java"
 @".str.1" = vector<i32> "Test Passed!\00"
 @".str.2" = vector<i32> "Test Failed!\00"
 
-func void @printIfTrue(%testClass* %0):
+func void @printIfTrue(%testClass* %self):
 entry:
+	%self.local = alloc %testClass*
+	store %testClass* %self, %testClass** %self.local
+	%0 = load %testClass* %self.local
 	%1 = getptr bool* %0, 1
 	%2 = load bool %1
 	%3 = cmp eq, %2, true

--- a/examples/add.java
+++ b/examples/add.java
@@ -1,0 +1,17 @@
+class Adder {
+    public static void main (String[] args) {
+        System.out.println(new Math().add());
+    }
+}
+
+class Math {
+    public int add() {
+        int x;
+        int y;
+
+        x = 1;
+        y = 2;
+        x = x + y;
+        return x;
+    }
+}

--- a/include/minijavab/core/ir/Function.h
+++ b/include/minijavab/core/ir/Function.h
@@ -4,6 +4,7 @@
 #include <list>
 
 #include "minijavab/core/ir/Value.h"
+#include "minijavab/core/ir/Parameter.h"
 
 namespace MiniJavab {
 namespace Core {
@@ -33,11 +34,28 @@ class Function : public Value {
         /// @return The newly created, and inserted, basic block
         BasicBlock* CreateBlock(std::string name);
 
+        /// Get the list of parameters used by this function
+        /// @return A copy of the list of function parameters
+        std::vector<Parameter*> GetParameters() const;
+
+        /// Lookup a function parameter by known name
+        /// @see GetParameters()
+        /// @return The parameter if it exists, else nullptr
+        Parameter* GetParameterByName(std::string name) const;
+
+        /// Lookup a function parameter by known index
+        /// @see GetParameters()
+        /// @return the Parameter if it exists, else nullptr
+        Parameter* GetParameterByIndex(size_t index) const;
+
         /// The list of Basic Blocks in this function
         std::list<BasicBlock*> BasicBlocks;
 
         /// The name of this function
         std::string Name;
+    private:
+        /// List of parameters passed to this function
+        std::vector<Parameter*> _parameterList;
 };
 
 }}} // end namespace

--- a/include/minijavab/core/ir/IRBuilder.h
+++ b/include/minijavab/core/ir/IRBuilder.h
@@ -17,20 +17,28 @@ class IRBuilder {
         /// @param block The Basic Block
         IRBuilder(BasicBlock* block);
 
-        /// Update the underlying Basic Block to insert instructions into
-        /// @param block The new basic block
-        void SetBlock(BasicBlock* block);
-
         /// Create a Return Instruction
         /// @see RetInstruction::RetInstruction()
         /// @return The newly created Return Instruction
         Value* CreateRet(Value* value=nullptr);
 
+        /// Create a Allocation Instruction
+        /// @see AllocInstruction::AllocInstruction()
+        /// @return The newly created Allocation Instruction
         Value* CreateAlloc(IR::Type* localType, std::string name);
 
-    private:
+        /// Create a Store Instruction
+        /// @see StoreInstruction::StoreInstruction()
+        /// @return The newly created Store Instruction
+        Value* CreateStore(Value* object, Value* pointer);
+
+        /// Wrapper function for inserting a created instruction into the block
+        /// @see BasicBlock::AppendInstruction
+        /// @param instruction The instruction to insert
+        void Insert(Instruction* instruction);
+
         /// The Basic Block to insert newly created instructions into
-        BasicBlock* _block = nullptr;
+        BasicBlock* Block = nullptr;
 };
 
 }}} // end namespace

--- a/include/minijavab/core/ir/IRBuilder.h
+++ b/include/minijavab/core/ir/IRBuilder.h
@@ -26,6 +26,8 @@ class IRBuilder {
         /// @return The newly created Return Instruction
         Value* CreateRet(Value* value=nullptr);
 
+        Value* CreateAlloc(IR::Type* localType, std::string name);
+
     private:
         /// The Basic Block to insert newly created instructions into
         BasicBlock* _block = nullptr;

--- a/include/minijavab/core/ir/Instruction.h
+++ b/include/minijavab/core/ir/Instruction.h
@@ -18,7 +18,7 @@ class Instruction : public Value {
         /// Print the textual representation of this constant to the given stream.
         /// Useful for chaining multiple Print() calls into one
         /// @param out The stream to print to
-        void Print(std::ostream& out = std::cerr) const;
+        virtual void Print(std::ostream& out = std::cerr) const;
 
         /// Whether or not this instruction returns a value for immediate usage
         /// @returns True if this instruction returns a value, else False

--- a/include/minijavab/core/ir/Instructions/Alloc.h
+++ b/include/minijavab/core/ir/Instructions/Alloc.h
@@ -11,7 +11,9 @@ namespace IR {
 /// Represents an Allocation Instruction for allocating space for a local variable
 class AllocInstruction : public Instruction {
     public:
-        
+        /// Create a alloc instruction that allocates space for a given type
+        /// @param localType The type to allocate space for/the local variable type
+        /// @param name The name of the yielded value/local variable
         AllocInstruction(IR::Type* localType, std::string name);
 
         bool YieldsValue() const override { return true; }

--- a/include/minijavab/core/ir/Instructions/Alloc.h
+++ b/include/minijavab/core/ir/Instructions/Alloc.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "minijavab/core/ir/Instruction.h"
+
+#include <string>
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+/// Represents an Allocation Instruction for allocating space for a local variable
+class AllocInstruction : public Instruction {
+    public:
+        
+        AllocInstruction(IR::Type* localType, std::string name);
+
+        bool YieldsValue() const override { return true; }
+
+        /// Print the textual representation of this constant to the given stream.
+        /// Useful for chaining multiple Print() calls into one
+        /// @param out The stream to print to
+        void Print(std::ostream& out = std::cerr) const override;
+};
+
+}}} // end namespace

--- a/include/minijavab/core/ir/Instructions/Opcodes.h
+++ b/include/minijavab/core/ir/Instructions/Opcodes.h
@@ -76,6 +76,8 @@ inline std::string GetInstructionName(const Opcode opcode) {
         case Opcode::RetImmediate:
         case Opcode::RetValue:
             return "ret";
+        case Opcode::Alloc:
+            return "alloc";
         default:
             assert(false && "Instruction not added yet!");
     }

--- a/include/minijavab/core/ir/Instructions/Opcodes.h
+++ b/include/minijavab/core/ir/Instructions/Opcodes.h
@@ -55,10 +55,8 @@ enum class Opcode {
     Alloc,
     /// Load from a local variable
     Load,
-    /// Store a value into a local variable
-    StoreValue,
-    /// Store an immediate into a local variable
-    StoreImmediate,
+    /// Store a value into memory
+    Store,
     /// Get a pointer to a value
     GetPtrValue,
     /// Get a pointer with an immediate value
@@ -78,6 +76,8 @@ inline std::string GetInstructionName(const Opcode opcode) {
             return "ret";
         case Opcode::Alloc:
             return "alloc";
+        case Opcode::Store:
+            return "store";
         default:
             assert(false && "Instruction not added yet!");
     }

--- a/include/minijavab/core/ir/Instructions/Store.h
+++ b/include/minijavab/core/ir/Instructions/Store.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "minijavab/core/ir/Instruction.h"
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+/// Represents a Store Instruction for storing values into memory
+class StoreInstruction : public Instruction {
+    public:
+        /// Create a store instruction storing object into memory
+        /// pointed to by pointer
+        /// @param object The object to store
+        /// @param pointer Pointer to memory
+        StoreInstruction(Value* object, Value* pointer);
+
+        bool YieldsValue() const override { return false; }
+
+        /// Print the textual representation of this constant to the given stream.
+        /// Useful for chaining multiple Print() calls into one
+        /// @param out The stream to print to
+        void Print(std::ostream& out = std::cerr) const override;
+
+    private:
+        /// The value being stored
+        Value* _object;
+
+        /// Where to store the value
+        Value* _pointer;
+};
+
+}}} // end namespace

--- a/include/minijavab/core/ir/Parameter.h
+++ b/include/minijavab/core/ir/Parameter.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "minijavab/core/ir/Value.h"
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+/// Describes a function parameter that's passed into a function on invocation
+class Parameter: public Value {
+    public:
+        /// Construct a parameter with a given type
+        /// @param type The type of the parameter
+        /// @param index The index of this parameter within the function's list of parameters
+        Parameter(IR::Type* type, size_t index);
+
+        /// Construct a parameter with a given type and name
+        /// @param type The type of the parameter
+        /// @param name The name of the parameter
+        /// @param index The index of this parameter within the function's list of parameters
+        Parameter(IR::Type* type, std::string name, size_t index);
+
+        void Print(std::ostream& out = std::cerr) const override;
+
+        /// Get the index of this parameter within the function's list of parameters
+        /// @return The parameter index
+        size_t GetIndex() const;
+
+    private:
+        /// The index of this parameter within the function's list of parameters
+        size_t _index;
+};
+
+}}} // end namespace

--- a/include/minijavab/frontend/Converter.h
+++ b/include/minijavab/frontend/Converter.h
@@ -27,6 +27,11 @@ class ASTConverter {
         /// @param fileName The original filename the AST was generated from (used for module naming)
         /// @return The IR form if successfully converted, nullptr otherwise
         static Core::IR::Module* Convert(AST::ProgramNode* program, ASTClassTable* table, std::string fileName);
+
+        /// Resolve an AST Type to an IR-equivalent type
+        /// @param type The AST Type to resolve
+        /// @return The new IR type
+        Core::IR::Type* ResolveASTType(Frontend::AST::Type* type);
     protected:
         /// Creates the metadata global variables for the AST
         void CreateClassMetadata();
@@ -49,11 +54,6 @@ class ASTConverter {
         /// @param method The method to create a type for
         /// @return The newly created global variable that's been added to the module
         Core::IR::GlobalVariable* CreateMetadataMethod(ASTClass* parentClass, ASTMethod* method);
-
-        /// Resolve an AST Type to an IR-equivalent type
-        /// @param type The AST Type to resolve
-        /// @return The new IR type
-        Core::IR::Type* ResolveASTType(Frontend::AST::Type* type);
     private:
         ASTConverter(ASTClassTable* table, std::string fileName);
 

--- a/include/minijavab/frontend/InstructionLowering.h
+++ b/include/minijavab/frontend/InstructionLowering.h
@@ -43,6 +43,10 @@ class InstructionLowering {
         /// @param function The empty destination IR function
         void LowerFunction(ASTMethod* methodDefinition, Core::IR::Function* function);
 
+        /// Create any local variables needed for the function and save parameter values
+        /// @param methodDefinition The AST definition of the function
+        /// @param builder The IRBuilder
+        /// @return A symbol table for local variables/parameters used by this function
         FunctionSymbolTable CreateLocalVariables(ASTMethod* methodDefinition, Core::IR::IRBuilder& builder);
 
     private:

--- a/include/minijavab/frontend/InstructionLowering.h
+++ b/include/minijavab/frontend/InstructionLowering.h
@@ -1,11 +1,14 @@
 #pragma once
 #include "minijavab/frontend/frontend.h"
 
+#include <map>
+
 namespace MiniJavab {
 namespace Core {
 namespace IR {
     class Function;
     class Value;
+    class IRBuilder;
 }} // end Core::IR namespace
 
 namespace Frontend {
@@ -28,6 +31,8 @@ class InstructionLowering {
         FunctionSymbolEntry* copiedSymbol = nullptr;
     };
 
+    using FunctionSymbolTable = std::map<std::string, FunctionSymbolEntry*>;
+
     public:
         /// Construct an InstructionLowering object associated with a Converter object
         /// @param converter The Converter object constructing this object
@@ -37,6 +42,8 @@ class InstructionLowering {
         /// @param methodDefinition The AST definition of the function
         /// @param function The empty destination IR function
         void LowerFunction(ASTMethod* methodDefinition, Core::IR::Function* function);
+
+        FunctionSymbolTable CreateLocalVariables(ASTMethod* methodDefinition, Core::IR::IRBuilder& builder);
 
     private:
         /// A reference to the main Converter object

--- a/src/core/ir/Function.cpp
+++ b/src/core/ir/Function.cpp
@@ -8,16 +8,24 @@ namespace IR {
 
 Function::Function(std::string name, FunctionType* type)
     : Value(type),
-    Name(name) {}
+    Name(name) {
+    // Construct the parameter list
+    _parameterList.resize(type->ParameterTypes.size());
+    for (size_t i = 0; i < type->ParameterTypes.size(); i++)
+    {
+        _parameterList[i] = new Parameter(type->ParameterTypes[i], i);
+    }
+}
 
 void Function::Print(std::ostream& out) const {
     FunctionType* functionType = static_cast<FunctionType*>(ValueType);
 
     out << functionType->ReturnType->GetString() << " " << Name << " (";
-    for (size_t i = 0; i < functionType->ParameterTypes.size(); i++) {
-        out << functionType->ParameterTypes[i]->GetString();
+    for (size_t i = 0; i < _parameterList.size(); i++) {
+        const Parameter* parameter = _parameterList[i];
 
-        if ((i + 1) < functionType->ParameterTypes.size()) {
+        parameter->Print(out);
+        if ((i + 1) < _parameterList.size()) {
             out << ", ";
         }
     }
@@ -55,6 +63,27 @@ BasicBlock* Function::CreateBlock(std::string name) {
     AppendBasicBlock(block);
 
     return block;
+}
+
+std::vector<Parameter*> Function::GetParameters() const {
+    return _parameterList;
+}
+
+Parameter* Function::GetParameterByName(std::string name) const {
+    for (Parameter* parameter: _parameterList) {
+        if (parameter->HasName() && parameter->Name == name) {
+            return parameter;
+        }
+    }
+    return nullptr;
+}
+
+Parameter* Function::GetParameterByIndex(size_t index) const {
+    if (index < _parameterList.size()) {
+        return _parameterList[index];
+    }
+
+    return nullptr;
 }
 
 }}} // end namespace

--- a/src/core/ir/IRBuilder.cpp
+++ b/src/core/ir/IRBuilder.cpp
@@ -2,30 +2,38 @@
 
 #include "minijavab/core/ir/Instructions/Ret.h"
 #include "minijavab/core/ir/Instructions/Alloc.h"
+#include "minijavab/core/ir/Instructions/Store.h"
 
 namespace MiniJavab {
 namespace Core {
 namespace IR {
 
 IRBuilder::IRBuilder(BasicBlock* block)
-    : _block(block) {}
-
-void IRBuilder::SetBlock(BasicBlock* block) {
-    _block = block;
-}
+    : Block(block) {}
 
 Value* IRBuilder::CreateRet(Value* value) {
     Instruction* instruction = new RetInstruction();
-    _block->AppendInstruction(instruction);
+    Insert(instruction);
 
     return instruction;
 }
 
 Value* IRBuilder::CreateAlloc(IR::Type* localType, std::string name) {
     Instruction* instruction = new AllocInstruction(localType, name);
-    _block->AppendInstruction(instruction);
+    Insert(instruction);
 
     return instruction;
+}
+
+Value* IRBuilder::CreateStore(Value* object, Value* pointer) {
+    Instruction* instruction = new StoreInstruction(object, pointer);
+    Insert(instruction);
+
+    return instruction;
+}
+
+void IRBuilder::Insert(Instruction* instruction) {
+    Block->AppendInstruction(instruction);
 }
 
 }}} // end namespace

--- a/src/core/ir/IRBuilder.cpp
+++ b/src/core/ir/IRBuilder.cpp
@@ -1,6 +1,7 @@
 #include "minijavab/core/ir/IRBuilder.h"
 
 #include "minijavab/core/ir/Instructions/Ret.h"
+#include "minijavab/core/ir/Instructions/Alloc.h"
 
 namespace MiniJavab {
 namespace Core {
@@ -14,10 +15,17 @@ void IRBuilder::SetBlock(BasicBlock* block) {
 }
 
 Value* IRBuilder::CreateRet(Value* value) {
-    Instruction* retInstruction = new RetInstruction();
-    _block->AppendInstruction(retInstruction);
+    Instruction* instruction = new RetInstruction();
+    _block->AppendInstruction(instruction);
 
-    return retInstruction;
-} 
+    return instruction;
+}
+
+Value* IRBuilder::CreateAlloc(IR::Type* localType, std::string name) {
+    Instruction* instruction = new AllocInstruction(localType, name);
+    _block->AppendInstruction(instruction);
+
+    return instruction;
+}
 
 }}} // end namespace

--- a/src/core/ir/Instructions/Alloc.cpp
+++ b/src/core/ir/Instructions/Alloc.cpp
@@ -1,0 +1,18 @@
+#include "minijavab/core/ir/Instructions/Alloc.h"
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+AllocInstruction::AllocInstruction(IR::Type* localType, std::string name)
+    : Instruction(Opcode::Alloc, localType) {
+    Name = name;
+}
+
+void AllocInstruction::Print(std::ostream& out) const {
+    Instruction::Print(out);
+
+    out << " " << ValueType->GetString();
+}
+
+}}} // end namespace

--- a/src/core/ir/Instructions/Alloc.cpp
+++ b/src/core/ir/Instructions/Alloc.cpp
@@ -5,7 +5,7 @@ namespace Core {
 namespace IR {
 
 AllocInstruction::AllocInstruction(IR::Type* localType, std::string name)
-    : Instruction(Opcode::Alloc, localType) {
+    : Instruction(Opcode::Alloc, /*localType*/ new IR::PointerType(localType)) {
     Name = name;
 }
 

--- a/src/core/ir/Instructions/Store.cpp
+++ b/src/core/ir/Instructions/Store.cpp
@@ -1,0 +1,28 @@
+#include "minijavab/core/ir/Instructions/Store.h"
+
+#include <cassert>
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+StoreInstruction::StoreInstruction(Value* object, Value* pointer)
+    : Instruction(Opcode::Store, new IR::VoidType()),
+        _object(object),
+        _pointer(pointer) {
+    assert(pointer->ValueType->IsPointerType());
+
+    IR::Type* elementType = static_cast<PointerType*>(pointer->ValueType)->ElementType;
+    assert(object->ValueType->GetTypeKind() == elementType->GetTypeKind());
+}
+
+void StoreInstruction::Print(std::ostream& out) const {
+    Instruction::Print(out);
+
+    out << " ";
+    _object->Print(out);
+    out << ", ";
+    _pointer->Print(out);
+}
+
+}}} // end namespace

--- a/src/core/ir/Parameter.cpp
+++ b/src/core/ir/Parameter.cpp
@@ -1,0 +1,23 @@
+#include "minijavab/core/ir/Parameter.h"
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+Parameter::Parameter(IR::Type* type, size_t index)
+        : Value(type),
+        _index(index) {}
+
+Parameter::Parameter(IR::Type* type, std::string name, size_t index)
+            : Value(type, name),
+            _index(index) {}
+
+size_t Parameter::GetIndex() const {
+    return _index;
+}
+
+void Parameter::Print(std::ostream& out) const {
+    out << ValueType->GetString() << " %" << (HasName() ? Name : (std::to_string(_index)));
+}
+
+}}} // end namespace

--- a/src/frontend/Converter.cpp
+++ b/src/frontend/Converter.cpp
@@ -226,8 +226,12 @@ void ASTConverter::CreateFunctionSignatures() {
 
             // Resolve parameter types
             std::vector<IR::Type*> parameterTypes;
+            std::vector<std::string> parameterNames;
+            parameterTypes.reserve(methodDefinition->Parameters.size());
+            parameterNames.reserve(methodDefinition->Parameters.size());
             for (auto& [parameterName, parameterDefinition] : methodDefinition->Parameters) {
                 parameterTypes.push_back(ResolveASTType(parameterDefinition->Type));
+                parameterNames.push_back(parameterName);
             }
 
             // Create function type
@@ -236,6 +240,11 @@ void ASTConverter::CreateFunctionSignatures() {
             // Create function and add it to the module
             IR::Function* function = new IR::Function(functionName, functionType);
             _module->AddFunction(function);
+
+            // Assign parameter names
+            for (IR::Parameter* functionParameter : function->GetParameters()) {
+                functionParameter->Name = parameterNames[functionParameter->GetIndex()];
+            }
         }
     }
 }

--- a/src/frontend/InstructionLowering.cpp
+++ b/src/frontend/InstructionLowering.cpp
@@ -20,9 +20,14 @@ InstructionLowering::FunctionSymbolTable InstructionLowering::CreateLocalVariabl
 
     // Create local variables for each passed-in parameter
     for (auto& [parameterName, parameter] : methodDefinition->Parameters) {
+        IR::Parameter* functionParameter = builder.Block->ParentFunction->GetParameterByName(parameterName);
+
         // Create a new local variable as a copy of the passed-in parameter
         IR::Value* localVariable = builder.CreateAlloc(_converter->ResolveASTType(parameter->Type),
                                                             parameterName + ".local");
+        
+        // Store the passed-in parameter into the local variable
+        builder.CreateStore(functionParameter, localVariable);
 
         // Create two symbol table entries, one for the passed-in parameter and one for the copy
         FunctionSymbolEntry* localEntry = new FunctionSymbolEntry {
@@ -32,7 +37,7 @@ InstructionLowering::FunctionSymbolTable InstructionLowering::CreateLocalVariabl
         };
 
         FunctionSymbolEntry* parameterEntry = new FunctionSymbolEntry {
-            /*Value*/ nullptr,  // TODO: Get the parameter as a value somehow
+            /*Value*/ functionParameter,
             /*isParameter*/ true,
             /*copiedSymbol*/ localEntry
         };

--- a/src/frontend/InstructionLowering.cpp
+++ b/src/frontend/InstructionLowering.cpp
@@ -15,13 +15,55 @@ namespace Frontend {
 InstructionLowering::InstructionLowering(ASTConverter* converter)
                         : _converter(converter) {}
 
+InstructionLowering::FunctionSymbolTable InstructionLowering::CreateLocalVariables(ASTMethod* methodDefinition, Core::IR::IRBuilder& builder) {
+    FunctionSymbolTable functionSymbolTable;
+
+    // Create local variables for each passed-in parameter
+    for (auto& [parameterName, parameter] : methodDefinition->Parameters) {
+        // Create a new local variable as a copy of the passed-in parameter
+        IR::Value* localVariable = builder.CreateAlloc(_converter->ResolveASTType(parameter->Type),
+                                                            parameterName + ".local");
+
+        // Create two symbol table entries, one for the passed-in parameter and one for the copy
+        FunctionSymbolEntry* localEntry = new FunctionSymbolEntry {
+            /*Value*/ localVariable,
+            /*isParameter*/ false,
+            /*copiedSymbol*/ nullptr
+        };
+
+        FunctionSymbolEntry* parameterEntry = new FunctionSymbolEntry {
+            /*Value*/ nullptr,  // TODO: Get the parameter as a value somehow
+            /*isParameter*/ true,
+            /*copiedSymbol*/ localEntry
+        };
+
+        functionSymbolTable.insert({localVariable->Name, localEntry});
+        functionSymbolTable.insert({parameterName, parameterEntry});
+    }
+
+    // Create local variables for each variable declaration in the method
+    for (auto& [variableName, variable] : methodDefinition->Variables) {
+        IR::Value* localVariable = builder.CreateAlloc(_converter->ResolveASTType(variable->Type),
+                                                            variableName);
+
+        functionSymbolTable.insert({variableName, new FunctionSymbolEntry {
+            /*Value*/ localVariable,
+            /*isParameter*/ false,
+            /*copiedSymbol*/ nullptr
+        }});
+    }
+
+    return functionSymbolTable;
+}
+
 void InstructionLowering::LowerFunction(ASTMethod* methodDefinition, Core::IR::Function* function) {
-    // Create Function Symbol Table
-
-    // Create entry block
+    // Create entry block and an IR Builder to use it
     IR::BasicBlock* entryBlock = function->CreateBlock("entry");
-
     IR::IRBuilder builder(entryBlock);
+
+    // Convert any function parameters to local variables
+    FunctionSymbolTable functionSymbolTable = CreateLocalVariables(methodDefinition, builder);
+
     builder.CreateRet();
 }
 


### PR DESCRIPTION
This PR starts the function lowering process and implements support for creating local variables as well as saving function parameters as local variables.

Example IR output:
```
void Adder_main (vector<vector<i8>> %args)
entry:
	alloc vector<vector<i8>>*
	store vector<vector<i8>> %args, alloc vector<vector<i8>>*
	ret
```