### PR TITLE
Add pretty printing for functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ add_library(core SHARED
     src/core/ir/Instruction.cpp
     src/core/ir/IRBuilder.cpp
     src/core/ir/Parameter.cpp
+    src/core/ir/ValuePrinter.cpp
+    src/core/ir/PrinterImpl.cpp
     ${INSTRUCTIONS})
 
 # Build AST target

--- a/include/minijavab/core/ir/PrinterImpl.h
+++ b/include/minijavab/core/ir/PrinterImpl.h
@@ -7,14 +7,27 @@ namespace IR {
 class Value;
 class ValuePrinter;
 
+/// Implements a printer object for the ValuePrinter implementation
 class PrinterImpl {
     public:
+        /// Constructs a new PrinterImpl with a shared ValuePrinter instance
+        /// @param printer The shared ValuePrinter instance, may not be null
         PrinterImpl(ValuePrinter* printer);
         ~PrinterImpl();
 
+        /// Prints an IR::Value object to the output stream. Named IR::Value objects will be
+        /// printed as their name, unnamed objects will be assigned a temporary ID that will be
+        /// printed instead.
+        /// @param out The output stream to print to
+        /// @param value The value to print
         void Print(std::ostream& out, const Value* value);
+
+        /// Similar to Print(), but prints IR::Value objects without any typing information 
+        /// @param out The output stream to print to
+        /// @param value The value to print
         void PrintNoType(std::ostream& out, const Value* value);
     private:
+        /// The shared printer instance
         ValuePrinter* _printer;
 };
 

--- a/include/minijavab/core/ir/PrinterImpl.h
+++ b/include/minijavab/core/ir/PrinterImpl.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <iostream>
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+class Value;
+class ValuePrinter;
+
+class PrinterImpl {
+    public:
+        PrinterImpl(ValuePrinter* printer);
+        ~PrinterImpl();
+
+        void Print(std::ostream& out, const Value* value);
+        void PrintNoType(std::ostream& out, const Value* value);
+    private:
+        ValuePrinter* _printer;
+};
+
+}}} // end namespace

--- a/include/minijavab/core/ir/ValuePrinter.h
+++ b/include/minijavab/core/ir/ValuePrinter.h
@@ -8,22 +8,58 @@ namespace IR {
 class Value;
 class PrinterImpl;
 
+/// Implements shared stateful printing for IR::Value objects. Implements an RAII-esque interface to share
+/// state across multiple "printer methods". Printer methods may use the ValuePrinter interface to print an
+/// IR::Value object as a reference-able temporary (ex: %1) or named value (ex: %foo).
 class ValuePrinter {
     public:
+        /// Initializes a new shared state and returns a printer object for use. Any existing valid state
+        /// is overwritten with this call
+        /// @return The new printer object
         static PrinterImpl Initialize();
+
+        /// Gets the printer object for the currently initialized state. If no state exists, then a new
+        /// one will be created similarly to Initialize().
+        /// @return The printer object
         static PrinterImpl Get();
-        void Print(std::ostream& out, const Value* value);
-        void PrintNoType(std::ostream& out, const Value* value);
     private:
+        /// Prints a Value
+        /// @see PrinterImpl::Print()
+        void Print(std::ostream& out, const Value* value);
+
+        /// Prints a Value without typing information
+        /// @see PrinterImpl::PrintNoType()
+        void PrintNoType(std::ostream& out, const Value* value);
+
+        /// Creates a new printer object with the shared state and updates tracking information
+        /// @return A new printer initialized with the shared instance
         PrinterImpl createImpl();
+
+        /// Callback to indicate that a printer object was destroyed and updates tracking information.
+        /// If all printer instances have been destroyed, the shared state instance will also be destroyed.
+        /// @note This is called by printer objects during object destruction
         void implWasDestroyed();
 
+        /// Helper function for getting the printable name of an IR::Value object
+        /// @param value The object to get a name for
+        /// @return The name or temporary id to print for the IR::Value object
+        std::string getName(const Value* value);
+
+        /// A mapping of known Value objects to their naming information. Values with known names, see 
+        /// Value::HasName(), will have their actual name recorded, see Value::GetName(). Values without
+        /// a known name will be a assigned a temporary name
         std::unordered_map<const Value*, std::string> _valueMap;
+
+        /// Number of un-named temporaries within _valueMap. Used to name new temporaries.
         size_t _temporaryCount = 0;
 
+        /// Number of printer objects that exist.
         static inline uint32_t _instanceCount = 0;
+
+        /// The shared state object
         static inline ValuePrinter* _instance = nullptr;
 
+        /// PrinterImpl has friendship so that it may access the destruction callback and the printer methods
         friend class PrinterImpl;
 };
 

--- a/include/minijavab/core/ir/ValuePrinter.h
+++ b/include/minijavab/core/ir/ValuePrinter.h
@@ -1,0 +1,30 @@
+#include <ostream>
+#include <map>
+#include <string>
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+class Value;
+class PrinterImpl;
+
+class ValuePrinter {
+    public:
+        static PrinterImpl Initialize();
+        static PrinterImpl Get();
+        void Print(std::ostream& out, const Value* value);
+        void PrintNoType(std::ostream& out, const Value* value);
+    private:
+        PrinterImpl createImpl();
+        void implWasDestroyed();
+
+        std::unordered_map<const Value*, std::string> _valueMap;
+        size_t _temporaryCount = 0;
+
+        static inline uint32_t _instanceCount = 0;
+        static inline ValuePrinter* _instance = nullptr;
+
+        friend class PrinterImpl;
+};
+
+}}} // end namespace

--- a/src/core/ir/Function.cpp
+++ b/src/core/ir/Function.cpp
@@ -1,6 +1,8 @@
 #include "minijavab/core/ir/Function.h"
 
 #include "minijavab/core/ir/BasicBlock.h"
+#include "minijavab/core/ir/ValuePrinter.h"
+#include "minijavab/core/ir/PrinterImpl.h"
 
 namespace MiniJavab {
 namespace Core {
@@ -18,6 +20,7 @@ Function::Function(std::string name, FunctionType* type)
 }
 
 void Function::Print(std::ostream& out) const {
+    PrinterImpl printer = ValuePrinter::Initialize();
     FunctionType* functionType = static_cast<FunctionType*>(ValueType);
 
     out << functionType->ReturnType->GetString() << " " << Name << " (";
@@ -39,8 +42,8 @@ void Function::Print(std::ostream& out) const {
 
         uint64_t temporaryCounter = 0;
         for (BasicBlock* block : BasicBlocks) {
-            if (block->HasName()) { out << block->Name << ":\n"; }
-            else { out << (temporaryCounter++) << ":\n"; }
+            printer.PrintNoType(out, block);
+            out << ":\n";
 
             for (Instruction* inst : block->Instructions) {
                 out << "\t";

--- a/src/core/ir/Instruction.cpp
+++ b/src/core/ir/Instruction.cpp
@@ -1,5 +1,8 @@
 #include "minijavab/core/ir/Instruction.h"
 
+#include "minijavab/core/ir/ValuePrinter.h"
+#include "minijavab/core/ir/PrinterImpl.h"
+
 namespace MiniJavab {
 namespace Core {
 namespace IR {
@@ -9,6 +12,11 @@ Instruction::Instruction(Opcode opcode, IR::Type* type)
                 _opcode(opcode) {}
 
 void Instruction::Print(std::ostream& out) const {
+    PrinterImpl printer = ValuePrinter::Get();
+    if (YieldsValue()) {
+        printer.PrintNoType(out, this);
+        out << " = ";
+    }
     out << GetInstructionName(_opcode);
 }
 

--- a/src/core/ir/Instructions/Store.cpp
+++ b/src/core/ir/Instructions/Store.cpp
@@ -24,13 +24,9 @@ void StoreInstruction::Print(std::ostream& out) const {
     Instruction::Print(out);
 
     out << " ";
-    //_object->Print(out);
     printer.Print(out, _object);
-    //printer.Print(out, _object);
     out << ", ";
     printer.Print(out, _pointer);
-    //printer.Print(out, _pointer);
-    //_pointer->Print(out);
 }
 
 }}} // end namespace

--- a/src/core/ir/Instructions/Store.cpp
+++ b/src/core/ir/Instructions/Store.cpp
@@ -1,5 +1,8 @@
 #include "minijavab/core/ir/Instructions/Store.h"
 
+#include "minijavab/core/ir/ValuePrinter.h"
+#include "minijavab/core/ir/PrinterImpl.h"
+
 #include <cassert>
 
 namespace MiniJavab {
@@ -17,12 +20,17 @@ StoreInstruction::StoreInstruction(Value* object, Value* pointer)
 }
 
 void StoreInstruction::Print(std::ostream& out) const {
+    PrinterImpl printer = ValuePrinter::Get();
     Instruction::Print(out);
 
     out << " ";
-    _object->Print(out);
+    //_object->Print(out);
+    printer.Print(out, _object);
+    //printer.Print(out, _object);
     out << ", ";
-    _pointer->Print(out);
+    printer.Print(out, _pointer);
+    //printer.Print(out, _pointer);
+    //_pointer->Print(out);
 }
 
 }}} // end namespace

--- a/src/core/ir/Parameter.cpp
+++ b/src/core/ir/Parameter.cpp
@@ -1,5 +1,8 @@
 #include "minijavab/core/ir/Parameter.h"
 
+#include "minijavab/core/ir/ValuePrinter.h"
+#include "minijavab/core/ir/PrinterImpl.h"
+
 namespace MiniJavab {
 namespace Core {
 namespace IR {
@@ -17,7 +20,8 @@ size_t Parameter::GetIndex() const {
 }
 
 void Parameter::Print(std::ostream& out) const {
-    out << ValueType->GetString() << " %" << (HasName() ? Name : (std::to_string(_index)));
+    PrinterImpl printer = ValuePrinter::Get();
+    printer.Print(out, this);
 }
 
 }}} // end namespace

--- a/src/core/ir/PrinterImpl.cpp
+++ b/src/core/ir/PrinterImpl.cpp
@@ -1,0 +1,23 @@
+#include "minijavab/core/ir/PrinterImpl.h"
+
+#include "minijavab/core/ir/ValuePrinter.h"
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+PrinterImpl::PrinterImpl(ValuePrinter* printer)
+    : _printer(printer) {}
+
+PrinterImpl::~PrinterImpl() {
+    _printer->implWasDestroyed();
+}
+
+void PrinterImpl::Print(std::ostream& out, const Value* value) {
+    _printer->Print(out, value);
+}
+
+void PrinterImpl::PrintNoType(std::ostream& out, const Value* value) {
+    _printer->PrintNoType(out, value);
+}
+
+}}} // end namespace

--- a/src/core/ir/ValuePrinter.cpp
+++ b/src/core/ir/ValuePrinter.cpp
@@ -30,21 +30,24 @@ void ValuePrinter::implWasDestroyed() {
 }
 
 std::string ValuePrinter::getName(const Value* value) {
-    // search for the value in the map
+    // search for the value in the map and return it if it exists
     std::unordered_map<const Value*, std::string>::iterator searchResult = _valueMap.find(value);
     if (searchResult != _valueMap.end()) {
         return searchResult->second;
     }
     else {
+        // if the value doesn't exist in the map, figure out its name and add it
         std::string valueName;
         if (value->HasName()) {
             valueName = value->Name;
         }
         else {
+            // If the value is unnamed, assign it a temporary id
             valueName = std::to_string(_temporaryCount);
             _temporaryCount += 1;
         }
 
+        // insert the value and its name into the map and then return the name
         _valueMap.insert({value, valueName});
         return valueName;
     }

--- a/src/core/ir/ValuePrinter.cpp
+++ b/src/core/ir/ValuePrinter.cpp
@@ -1,0 +1,78 @@
+#include "minijavab/core/ir/ValuePrinter.h"
+
+#include "minijavab/core/ir/PrinterImpl.h"
+#include "minijavab/core/ir/Value.h"
+
+namespace MiniJavab {
+namespace Core {
+namespace IR {
+
+PrinterImpl ValuePrinter::Initialize() {
+    _instance = new ValuePrinter();
+    return _instance->createImpl();
+}
+PrinterImpl ValuePrinter::Get() {
+    if (_instance == nullptr) {
+        return Initialize();
+    }
+    return _instance->createImpl();
+}
+PrinterImpl ValuePrinter::createImpl() {
+    _instanceCount += 1;
+    return PrinterImpl(_instance);
+}
+void ValuePrinter::implWasDestroyed() {
+    _instanceCount -= 1;
+    if (_instanceCount == 0) {
+        delete _instance;
+        _instance = nullptr;
+    }
+}
+
+void ValuePrinter::Print(std::ostream& out, const Value* value) {
+    std::string valueName;
+    
+    // search for the value in the map
+    std::unordered_map<const Value*, std::string>::iterator searchResult = _valueMap.find(value);
+    if (searchResult != _valueMap.end()) {
+        valueName = searchResult->second;
+    }
+    else {
+        if (value->HasName()) {
+            valueName = value->Name;
+        }
+        else {
+            valueName = std::to_string(_temporaryCount);
+            _temporaryCount += 1;
+        }
+
+        _valueMap.insert({value, valueName});
+    }
+
+    out << value->ValueType->GetString() << " %" << valueName;
+}
+
+void ValuePrinter::PrintNoType(std::ostream& out, const Value* value) {
+    std::string valueName;
+    
+    // search for the value in the map
+    std::unordered_map<const Value*, std::string>::iterator searchResult = _valueMap.find(value);
+    if (searchResult != _valueMap.end()) {
+        valueName = searchResult->second;
+    }
+    else {
+        if (value->HasName()) {
+            valueName = value->Name;
+        }
+        else {
+            valueName = std::to_string(_temporaryCount);
+            _temporaryCount += 1;
+        }
+
+        _valueMap.insert({value, valueName});
+    }
+
+    out << "%" << valueName;
+}
+
+}}} // end namespace

--- a/src/core/ir/ValuePrinter.cpp
+++ b/src/core/ir/ValuePrinter.cpp
@@ -29,15 +29,14 @@ void ValuePrinter::implWasDestroyed() {
     }
 }
 
-void ValuePrinter::Print(std::ostream& out, const Value* value) {
-    std::string valueName;
-    
+std::string ValuePrinter::getName(const Value* value) {
     // search for the value in the map
     std::unordered_map<const Value*, std::string>::iterator searchResult = _valueMap.find(value);
     if (searchResult != _valueMap.end()) {
-        valueName = searchResult->second;
+        return searchResult->second;
     }
     else {
+        std::string valueName;
         if (value->HasName()) {
             valueName = value->Name;
         }
@@ -47,31 +46,17 @@ void ValuePrinter::Print(std::ostream& out, const Value* value) {
         }
 
         _valueMap.insert({value, valueName});
+        return valueName;
     }
+}
 
+void ValuePrinter::Print(std::ostream& out, const Value* value) {
+    std::string valueName = getName(value);
     out << value->ValueType->GetString() << " %" << valueName;
 }
 
 void ValuePrinter::PrintNoType(std::ostream& out, const Value* value) {
-    std::string valueName;
-    
-    // search for the value in the map
-    std::unordered_map<const Value*, std::string>::iterator searchResult = _valueMap.find(value);
-    if (searchResult != _valueMap.end()) {
-        valueName = searchResult->second;
-    }
-    else {
-        if (value->HasName()) {
-            valueName = value->Name;
-        }
-        else {
-            valueName = std::to_string(_temporaryCount);
-            _temporaryCount += 1;
-        }
-
-        _valueMap.insert({value, valueName});
-    }
-
+    std::string valueName = getName(value);
     out << "%" << valueName;
 }
 


### PR DESCRIPTION
This PR adds a shared printing implementation to share printing state amongst multiple printer methods.

Example output:
```
void Adder_main (vector<vector<i8>> %args)
%entry:
	%args.local = alloc vector<vector<i8>>*
	store vector<vector<i8>> %args, vector<vector<i8>>* %args.local
	ret
```